### PR TITLE
chore: update bash-functions URL from v2 to main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ REPO_BASE="https://raw.githubusercontent.com/oszuidwest/rpi-umpx-decoder/main"
 
 # Set-up the functions library
 FUNCTIONS_LIB_PATH=$(mktemp)
-FUNCTIONS_LIB_URL="https://raw.githubusercontent.com/oszuidwest/bash-functions/v2/common-functions.sh"
+FUNCTIONS_LIB_URL="https://raw.githubusercontent.com/oszuidwest/bash-functions/main/common-functions.sh"
 
 # Clean up temporary file on exit
 trap 'rm -f "$FUNCTIONS_LIB_PATH"' EXIT


### PR DESCRIPTION
Updates bash-functions URL from `v2` branch to `main`, since v2 is now the default branch.