### PR TITLE
Apply system hardening baseline in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,10 @@ if [ "$DO_UPDATES" == "y" ]; then
   apt_update --silent
 fi
 
+if declare -F set_system_hardening_baseline > /dev/null; then
+  set_system_hardening_baseline --silent
+fi
+
 # Add user for micrompx
 echo -e "${BLUE}►► Setting up micrompx user...${NC}"
 if ! id -u micrompx > /dev/null; then


### PR DESCRIPTION
## Summary
- call `set_system_hardening_baseline --silent` from the relevant Linux/Pi installer script(s)
- guard the call with `declare -F` so the installer remains compatible until the shared helper is merged
- uses the baseline added in https://github.com/oszuidwest/bash-functions/pull/14: disk health tooling, smart monitoring, and journald `SystemMaxUse=512M`

## Tests
- `bash -n install.sh`
- `shellcheck install.sh`